### PR TITLE
Updated foundation_renderer.rb to fully support ruby 1.8.7

### DIFF
--- a/lib/foundation_pagination/foundation_renderer.rb
+++ b/lib/foundation_pagination/foundation_renderer.rb
@@ -15,7 +15,7 @@ module FoundationPagination
       end.join(@options[:link_separator])
 
       if @options[:foundation].to_i >= 3
-        tag("ul", list_items, class: "pagination #{@options[:class]}")
+        tag("ul", list_items, :class => "pagination #{@options[:class]}")
       else
         html_container(tag("ul", list_items))
       end
@@ -32,7 +32,7 @@ module FoundationPagination
 
     def page_number(page)
       link_options = @options[:link_options] || {}
-      tag :li, link(page, page, link_options.merge(rel: rel_value(page))), :class => ('current' if page == current_page)
+      tag :li, link(page, page, link_options.merge(:rel => rel_value(page))), :class => ('current' if page == current_page)
     end
 
     def gap


### PR DESCRIPTION
All I did was switch some of the semi-colons to hash rockets so that I can use this gem with my ruby 1.8.7 rails app. Overall very small changes that have no negative effect as far as I can tell.

Thanks,
singerbj
