### PR TITLE
Update to support Foundation 6

### DIFF
--- a/lib/foundation_pagination/foundation_renderer.rb
+++ b/lib/foundation_pagination/foundation_renderer.rb
@@ -27,7 +27,7 @@ module FoundationPagination
       link_options = @options[:link_options] || {}
 
       if page == current_page
-        tag :li, link(page, ""), :class => ('current')
+        tag :li, tag(:span, page), :class => ('current')
       else
         tag :li, link(page, page, link_options.merge(:rel => rel_value(page)))
       end
@@ -38,22 +38,22 @@ module FoundationPagination
       if page
         tag :li, link(text, page, link_options), :class => classname
       else
-        tag :li, link(text, ""), :class => "%s unavailable" % classname
+        tag :li, tag(:span, text), :class => "%s disabled" % classname
       end
     end
 
     def gap
-      tag :li, tag('span','&hellip;'), :class => 'unavailable'
+      tag :li, '', :class => 'ellipsis'
     end
 
     def previous_page
       num = @collection.current_page > 1 && @collection.current_page - 1
-      previous_or_next_page(num, @options[:previous_label], "arrow")
+      previous_or_next_page(num, @options[:previous_label], "pagination-previous")
     end
 
     def next_page
       num = @collection.current_page < @collection.total_pages && @collection.current_page + 1
-      previous_or_next_page(num, @options[:next_label], "arrow")
+      previous_or_next_page(num, @options[:next_label], "pagination-next")
     end
 
   end


### PR DESCRIPTION
* Change unavailable class to disabled
* Use spans for current & disabled
* Use ellipsis class for page gap and remove text
* Use pagination-next/pagination-previous instead of arrow class

I'm not sure about the classes for arrows.  Using foundation's classes
automatically add an arrow.  Which means we have to add options to our
apps to change the labels to remove arrows.

```
will_paginate(
  object,
  renderer: FoundationPagination::Rails,
  previous_label: 'Previous',
  next_label: 'Next'
)
```