### PR TITLE
Remove deprecated Fixnum

### DIFF
--- a/lib/foundation_pagination/foundation_renderer.rb
+++ b/lib/foundation_pagination/foundation_renderer.rb
@@ -6,12 +6,7 @@ module FoundationPagination
 
     def to_html
       list_items = pagination.map do |item|
-        case item
-          when Fixnum
-            page_number(item)
-          else
-            send(item)
-        end
+        item.is_a?(Integer) ? page_number(item) : send(item)
       end.join(@options[:link_separator])
 
       tag("ul", list_items, :class => "pagination #{@options[:class]}")


### PR DESCRIPTION
In Ruby 2.4, Fixnum and Bignum are deprecated and their methods were
moved to Integer.

Instead of checking if the pagination item is a Fixnum, we now check if
it's an Integer.

Fixes #8